### PR TITLE
docs: fix 20 typos and grammar errors in comments

### DIFF
--- a/packages/coriolis/src/Coriolis.ts
+++ b/packages/coriolis/src/Coriolis.ts
@@ -132,7 +132,7 @@ export class Coriolis extends PostMessageChannel {
     initialContent: string,
   ) {
     if (!(target instanceof HTMLElement)) {
-      throw new TypeError('Excepted to have a HTMLElement object');
+      throw new TypeError('Expected to have a HTMLElement object');
     }
 
     let url;

--- a/packages/coriolis/src/DataSerializer.ts
+++ b/packages/coriolis/src/DataSerializer.ts
@@ -19,16 +19,16 @@ import {SerializerBase} from './SerializerBase';
 /**
  * A class that handles the stringification and parsing of the data that will be sent through PostMessage.
  * This has two main differences with JSON.parse/JSON.stringify.
- * - It allows loading custom domain serializer that could be loaded dynamically
+ * - It allows loading custom domain serializers that could be loaded dynamically
  * - It excludes from serialization all the property of objects which start with an "_" (underscore)
- * This allows having more than javascript primitive to be serialized and also to keep some property to be
+ * This allows having more than JavaScript primitives to be serialized and also to keep some property to be
  *  transferred because they shouldn't or they technically can't be transferred. For example, a security
  *  token might not be transferred or an HTMLElement reference couldn't be technically transferred. In that
  *  case, it could still be interesting to use it in a store but you never want them to be transferred.
  */
 export class DataSerializer {
   /**
-   * Internal array to save all custom serializer we have register
+   * Internal array to save all custom serializers we have registered
    * @type {Map}
    */
   private _serializers = new Map<string, SerializerBase>();
@@ -66,7 +66,7 @@ export class DataSerializer {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const myThis = this; // can't use closure since we need the JSON.stringify this
     return JSON.stringify(obj, function (k, v) {
-      // typeof => eject number and things that doesn't have match function
+      // typeof => reject number and things that don't have match function
       if (k !== '_serializerKey' && typeof k === 'string' && k.match(/^_/)) {
         return undefined;
       }
@@ -77,7 +77,7 @@ export class DataSerializer {
   }
 
   /**
-   * Call all custom serializer
+   * Call all custom serializers
    * @param  {Object}         obj         Object to serialize
    * @param  {any}            [fallback]  Default value if we can't find a dataSerializer for it
    * @return {Object|any}                 The value after the custom serializer or fallback
@@ -112,7 +112,7 @@ export class DataSerializer {
   }
 
   /**
-   * Call all custom serializer
+   * Call all custom serializers
    * @param  {any}    obj The current parse value
    * @return {any}    The value after the custom parse or the input obj
    */

--- a/packages/coriolis/src/ModuleLoader.ts
+++ b/packages/coriolis/src/ModuleLoader.ts
@@ -55,7 +55,7 @@ export class ModuleLoader
   /**
    * Add a module
    * @param {string} name The name of the module
-   * @param {Class} Module A module class to instanciate
+   * @param {Class} Module A module class to instantiate
    * @param {Object} config The configuration to pass to the module
    * @param {Boolean} alias If the module is directly available in postMessage class
    * @return {boolean} return if the module is correctly added

--- a/packages/coriolis/src/module/LoaderUtilModule.ts
+++ b/packages/coriolis/src/module/LoaderUtilModule.ts
@@ -23,7 +23,7 @@ import {ModuleBase} from '../ModuleBase';
  */
 export class LoaderUtilModule extends ModuleBase {
   /**
-   * Internal array to save all custom serializer we have register
+   * Internal array to save all custom serializers we have registered
    * @type {Map}
    */
   private _remoteModule = new Set<string>();
@@ -88,7 +88,7 @@ export class LoaderUtilModule extends ModuleBase {
 
       if (!this._moduleAreSame()) {
         console.error(
-          'Module are not in sync between the two frames.',
+          'Modules are not in sync between the two frames.',
           this.loaded(),
         );
       }

--- a/packages/coriolis/src/module/PluginModule.ts
+++ b/packages/coriolis/src/module/PluginModule.ts
@@ -40,7 +40,7 @@ export class PluginModule extends ModuleBase {
   }
 
   /**
-   * Register a set of plugin and solve the dependancy
+   * Register a set of plugin and solve the dependency
    * @param  {Object<Class>} plugins Class of each plugins with their respective names in keys
    * @return {void}
    */
@@ -64,8 +64,8 @@ export class PluginModule extends ModuleBase {
   /**
    * Add one plugin with his name and his class
    * @param  {String}   name    The plugin name/key
-   * @param  {CLass}    plugin  Class of the plugin to instanciate
-   * @return {Boolean}          If the plugin was added and instanciate or false if it's already present
+   * @param  {Class}    plugin  Class of the plugin to instantiate
+   * @return {Boolean}          If the plugin was added and instantiated or false if it's already present
    */
   add(name: string, plugin: Object) {
     if (this._plugins.has(name)) {
@@ -77,7 +77,7 @@ export class PluginModule extends ModuleBase {
   }
 
   /**
-   * Get the in stance of a plugin
+   * Get the instance of a plugin
    * @param  {String} name   The name of the plugin to get
    * @return {Object}        The instance of the plugin
    */
@@ -95,9 +95,9 @@ export class PluginModule extends ModuleBase {
   }
 
   /**
-   * Instanciate the plugin (with custom plugin factory if it was registered)
-   * @param  {String}  name  Plugin name/key to instanciate
-   * @return {Boolean}       If the plugin was instanciate
+   * Instantiate the plugin (with custom plugin factory if it was registered)
+   * @param  {String}  name  Plugin name/key to instantiate
+   * @return {Boolean}       If the plugin was instantiated
    */
   private _init(name: string) {
     const plugin = this._plugins.get(name);


### PR DESCRIPTION
## Summary

Fix 20 spelling, grammar, and capitalization issues across 5 source files:

- **Coriolis.ts**: `Excepted` → `Expected` in TypeError message
- **PluginModule.ts**: `dependancy` → `dependency`, `CLass` → `Class`, `instanciate` → `instantiate` (×6 occurrences), `in stance` → `instance`
- **DataSerializer.ts**: `serializer` → `serializers` (×4), `javascript primitive` → `JavaScript primitives`, `eject` → `reject`, `doesn't` → `don't`, `register` → `registered`
- **ModuleLoader.ts**: `instanciate` → `instantiate`
- **LoaderUtilModule.ts**: `serializer` → `serializers`, `register` → `registered`, `Module are` → `Modules are`

No functional changes — comment and JSDoc edits only, except for correcting a TypeError message string and a console.error string.